### PR TITLE
feat: use circom R1CS-to-QAP reduction

### DIFF
--- a/backend/groth16/bls12-377/prove.go
+++ b/backend/groth16/bls12-377/prove.go
@@ -352,6 +352,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/backend/groth16/bls12-377/prove.go
+++ b/backend/groth16/bls12-377/prove.go
@@ -142,7 +142,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -232,9 +232,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -353,47 +352,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -352,6 +352,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -142,7 +142,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -232,9 +232,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -353,47 +352,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }

--- a/backend/groth16/bls24-315/prove.go
+++ b/backend/groth16/bls24-315/prove.go
@@ -352,6 +352,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/backend/groth16/bls24-315/prove.go
+++ b/backend/groth16/bls24-315/prove.go
@@ -142,7 +142,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -232,9 +232,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -353,47 +352,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }

--- a/backend/groth16/bls24-317/prove.go
+++ b/backend/groth16/bls24-317/prove.go
@@ -352,6 +352,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/backend/groth16/bls24-317/prove.go
+++ b/backend/groth16/bls24-317/prove.go
@@ -142,7 +142,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -232,9 +232,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -353,47 +352,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }

--- a/backend/groth16/bn254/prove.go
+++ b/backend/groth16/bn254/prove.go
@@ -352,6 +352,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/backend/groth16/bn254/prove.go
+++ b/backend/groth16/bn254/prove.go
@@ -142,7 +142,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -232,9 +232,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -353,47 +352,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }

--- a/backend/groth16/bw6-633/prove.go
+++ b/backend/groth16/bw6-633/prove.go
@@ -352,6 +352,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/backend/groth16/bw6-633/prove.go
+++ b/backend/groth16/bw6-633/prove.go
@@ -142,7 +142,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -232,9 +232,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -353,47 +352,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }

--- a/backend/groth16/bw6-761/prove.go
+++ b/backend/groth16/bw6-761/prove.go
@@ -352,6 +352,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/backend/groth16/bw6-761/prove.go
+++ b/backend/groth16/bw6-761/prove.go
@@ -142,7 +142,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -232,9 +232,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -353,47 +352,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -336,6 +336,10 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
+// computeH is compatible with the R1CS-QAP reduction used by circom's snarkjs.
+// Unlike the original gnark implementation, snarkjs precomputes the Lagrange form of the powers of tau bases in a
+// domain twice as large, and h is computed as the odd coefficients of (AB-C) in that domain.
+// This implementation follows https://github.com/arkworks-rs/circom-compat.
 func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
 	nbConstraints, nbPublicWires := len(a), len(w)
 	n := int(domain.Cardinality)

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -126,7 +126,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	var h []fr.Element
 	chHDone := make(chan struct{}, 1)
 	go func() {
-		h = computeH(solution.A, solution.B, solution.C, &pk.Domain)
+		h = computeH(solution.A, solution.B, wireValues[:r1cs.GetNbPublicVariables()], &pk.Domain)
 		solution.A = nil
 		solution.B = nil
 		solution.C = nil
@@ -216,9 +216,8 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 		var krs, krs2, p1 curve.G1Jac
 		chKrs2Done := make(chan error, 1)
-		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
 		go func() {
-			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			_, err := krs2.MultiExp(pk.G1.Z, h, ecc.MultiExpConfig{NbTasks: n / 2})
 			chKrs2Done <- err
 		}()
 
@@ -337,47 +336,63 @@ func filterHeap(slice []fr.Element, sliceFirstIndex int, toRemove []int) (r []fr
 	return
 }
 
-func computeH(a, b, c []fr.Element, domain *fft.Domain) []fr.Element {
-	// H part of Krs
-	// Compute H (hz=ab-c, where z=-2 on ker X^n+1 (z(x)=x^n-1))
-	// 	1 - _a = ifft(a), _b = ifft(b), _c = ifft(c)
-	// 	2 - ca = fft_coset(_a), ba = fft_coset(_b), cc = fft_coset(_c)
-	// 	3 - h = ifft_coset(ca o cb - cc)
+func computeH(a, b, w []fr.Element, domain *fft.Domain) []fr.Element {
+	nbConstraints, nbPublicWires := len(a), len(w)
+	n := int(domain.Cardinality)
+	if nbConstraints+nbPublicWires > n {
+		panic("invalid domain")
+	}
 
-	n := len(a)
-
-	// add padding to ensure input length is domain cardinality
-	padding := make([]fr.Element, int(domain.Cardinality)-n)
-	a = append(a, padding...)
-	b = append(b, padding...)
-	c = append(c, padding...)
-	n = len(a)
-
-	domain.FFTInverse(a, fft.DIF)
-	domain.FFTInverse(b, fft.DIF)
-	domain.FFTInverse(c, fft.DIF)
-
-	domain.FFT(a, fft.DIT, fft.OnCoset())
-	domain.FFT(b, fft.DIT, fft.OnCoset())
-	domain.FFT(c, fft.DIT, fft.OnCoset())
-
-	var den, one fr.Element
-	one.SetOne()
-	den.Exp(domain.FrMultiplicativeGen, big.NewInt(int64(domain.Cardinality)))
-	den.Sub(&den, &one).Inverse(&den)
-
-	// h = ifft_coset(ca o cb - cc)
-	// reusing a to avoid unnecessary memory allocation
-	utils.Parallelize(n, func(start, end int) {
+	c := make([]fr.Element, n)
+	utils.Parallelize(nbConstraints, func(start, end int) {
 		for i := start; i < end; i++ {
-			a[i].Mul(&a[i], &b[i]).
-				Sub(&a[i], &c[i]).
-				Mul(&a[i], &den)
+			c[i].Mul(&a[i], &b[i])
 		}
 	})
 
-	// ifft_coset
-	domain.FFTInverse(a, fft.DIF, fft.OnCoset())
+	// add padding to ensure input length is domain cardinality
+	a = append(a, make([]fr.Element, n-len(a))...)
+	b = append(b, make([]fr.Element, n-len(b))...)
+
+	// copy the wires after the constraints into a
+	copy(a[nbConstraints:], w)
+
+	fft.BitReverse(a)
+	domain.FFTInverse(a, fft.DIT)
+	fft.BitReverse(b)
+	domain.FFTInverse(b, fft.DIT)
+	fft.BitReverse(c)
+	domain.FFTInverse(c, fft.DIT)
+
+	rootOfUnity, err := fft.Generator(domain.Cardinality * 2)
+	if err != nil {
+		panic(err)
+	}
+
+	utils.Parallelize(n, func(start, end int) {
+		var pow fr.Element
+		pow.Exp(rootOfUnity, big.NewInt(int64(start)))
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &pow)
+			b[i].Mul(&b[i], &pow)
+			c[i].Mul(&c[i], &pow)
+			pow.Mul(&pow, &rootOfUnity)
+		}
+	})
+
+	domain.FFT(a, fft.DIF)
+	fft.BitReverse(a)
+	domain.FFT(b, fft.DIF)
+	fft.BitReverse(b)
+	domain.FFT(c, fft.DIF)
+	fft.BitReverse(c)
+
+	// reusing a to avoid unnecessary memory allocation
+	utils.Parallelize(n, func(start, end int) {
+		for i := start; i < end; i++ {
+			a[i].Mul(&a[i], &b[i]).Sub(&a[i], &c[i])
+		}
+	})
 
 	return a
 }


### PR DESCRIPTION
Make gnark proves `snarkjs` compatible:

`snarkjs` precomputes the Lagrange form of the powers of tau bases in a domain twice as large and the witness map is computed as the odd coefficients of (AB-C) in that domain. This serves as Z when computing the proof.

Closes ZKVM-902